### PR TITLE
Add std2 extraction + npz-to-dataset rendering for Argon GEC CCP

### DIFF
--- a/32_Plasma/extract_result.py
+++ b/32_Plasma/extract_result.py
@@ -1,0 +1,139 @@
+"""
+Extract numeric result values from a saved COMSOL .mph via LiveLink for MATLAB.
+
+Bridge sequence is the same as matlab_data.py:
+  Python -> os.startfile('COMSOL ... with MATLAB.lnk') -> comsolinit.m
+        -> comsolstartup.m (cd + matlab.engine.shareEngine) -> connect_matlab.
+
+What is different from matlab_data.py:
+  no parameter sweep, no image export. We mphload the model once and pull
+  arrays back into Python via mpheval / mphinterp / mphglobal (nargout=1).
+"""
+
+import os
+import time
+import numpy as np
+import matlab.engine
+
+# ---- bridge config (same as 32_Plasma/matlab_data.py) ----
+SHORTCUT_PATH = r"C:\ProgramData\Microsoft\Windows\Start Menu\Programs\COMSOL Multiphysics 6.3"
+SHORTCUT_NAME = "COMSOL Multiphysics 6.3 with MATLAB.lnk"
+FULL_PATH = os.path.join(SHORTCUT_PATH, SHORTCUT_NAME)
+
+INPUT_MPH_PATH = os.path.normpath(r"D:\32_MoviLSTM\Argon_GEC_CCP\argon_gec_ccp.mph")
+OUT_DIR = os.path.normpath(r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted")
+
+# Which expressions to evaluate. Names must match the variables/operators
+# defined inside the .mph (open the model in COMSOL -> Model Builder, or run
+# the discover_expressions() helper below).
+FIELD_EXPRS = ["V", "ne", "Te"]      # field expressions on the mesh
+GLOBAL_EXPRS = ["intop1(ne)"]        # global / probe-style expressions
+
+
+def matlab_init(i_path):
+    """Launch COMSOL-with-MATLAB and connect to the shared engine."""
+    os.startfile(i_path)
+    time.sleep(5)
+    sessions = matlab.engine.find_matlab()
+    if sessions:
+        return matlab.engine.connect_matlab(sessions[0])
+    for _ in range(20):
+        time.sleep(3)
+        sessions = matlab.engine.find_matlab()
+        if sessions:
+            eng = matlab.engine.connect_matlab(sessions[0])
+            eng.eval("disp('Completed')", nargout=0)
+            return eng
+    raise RuntimeError("Failed to connect to MATLAB session after retries.")
+
+
+def load_model(eng, mph_path, tag="model"):
+    """mphload into a named MATLAB workspace variable."""
+    eng.eval(f"{tag} = mphload('{mph_path}');", nargout=0)
+    return tag
+
+
+def discover_expressions(eng, tag="model"):
+    """Print plot-group / dataset / variable tags so you know what to ask for.
+
+    mphnavigator(model) opens the model tree GUI; mphtags returns the tag
+    list for a given node. Useful when you do not yet know the names of
+    the field expressions inside this particular .mph.
+    """
+    eng.eval(f"disp(mphtags({tag}, 'result'));", nargout=0)
+    eng.eval(f"disp(mphtags({tag}.variable));", nargout=0)
+    # eng.eval(f"mphnavigator({tag});", nargout=0)  # uncomment for GUI tree
+
+
+def eval_field(eng, expr, tag="model", dataset=None):
+    """mpheval -> numpy arrays of mesh coords + values for one expression.
+
+    Returns (coords, values, time):
+        coords : (dim, N)   node coordinates
+        values : (T, N)     value at each node, per solution step
+        time   : (T,)       solution times (empty for stationary studies)
+    """
+    args = f"'{expr}'"
+    if dataset is not None:
+        args += f", 'dataset', '{dataset}'"
+    eng.eval(f"d = mpheval({tag}, {args});", nargout=0)
+    coords = np.asarray(eng.eval("d.p", nargout=1))
+    values = np.asarray(eng.eval("d.d1", nargout=1))
+    try:
+        t = np.asarray(eng.eval("d.t", nargout=1)).ravel()
+    except matlab.engine.MatlabExecutionError:
+        t = np.array([])
+    return coords, values, t
+
+
+def eval_global(eng, expr, tag="model"):
+    """mphglobal -> 1-D array of a scalar/global expression over time."""
+    eng.eval(f"g = mphglobal({tag}, '{expr}');", nargout=0)
+    return np.asarray(eng.eval("g", nargout=1)).ravel()
+
+
+def interp_at_points(eng, expr, points_xyz, tag="model"):
+    """mphinterp -> values of `expr` interpolated at user-supplied coordinates.
+
+    points_xyz : (dim, M) numpy array. dim is 2 for 2D models, 3 for 3D.
+    """
+    pts = matlab.double(points_xyz.tolist())
+    eng.workspace["pts"] = pts
+    eng.eval(f"v = mphinterp({tag}, '{expr}', 'coord', pts);", nargout=0)
+    return np.asarray(eng.eval("v", nargout=1))
+
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+    eng = matlab_init(FULL_PATH)
+    try:
+        load_model(eng, INPUT_MPH_PATH)
+
+        # Uncomment the first time you run on a new .mph:
+        # discover_expressions(eng)
+
+        bundle = {}
+        for expr in FIELD_EXPRS:
+            coords, values, t = eval_field(eng, expr)
+            bundle[f"{expr}_coords"] = coords
+            bundle[f"{expr}_values"] = values
+            bundle[f"{expr}_t"] = t
+            print(f"{expr}: coords {coords.shape}, values {values.shape}, t {t.shape}")
+
+        for expr in GLOBAL_EXPRS:
+            arr = eval_global(eng, expr)
+            safe = expr.replace("(", "_").replace(")", "").replace(" ", "")
+            bundle[f"global_{safe}"] = arr
+            print(f"{expr}: {arr.shape}")
+
+        out_path = os.path.join(OUT_DIR, "results.npz")
+        np.savez_compressed(out_path, **bundle)
+        print(f"saved -> {out_path}")
+    finally:
+        # Detach but leave MATLAB/COMSOL running so the next run reuses it.
+        # Call eng.exit() instead if you want to tear the session down.
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/32_Plasma/extract_std2.py
+++ b/32_Plasma/extract_std2.py
@@ -1,0 +1,295 @@
+"""
+Extract every std2 (Time Periodic to Time Dependent) field from saved .mph
+files of the argon_gec_ccp sweep, one .npz per case.
+
+Per case you get:
+    coords   (2, N_nodes)        r,z node coords (axisymmetric)
+    t        (51,)               time samples [0 .. 1/f0], seconds
+    <field>  (51, N_nodes)       one array per FIELD expression
+    g_<gx>   (51,)               one array per GLOBAL expression
+
+Reuses the same launch chain as 32_Plasma/matlab_data.py:
+    .lnk -> comsolinit.m -> comsolstartup.m (shareEngine) -> connect_matlab.
+
+Run on one file: set CASES_DIR = None and INPUT_MPH_PATH = '<file>.mph'.
+Run on the whole sweep: set CASES_DIR = 'D:/.../cas'.
+"""
+
+import glob
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+import matlab.engine
+import numpy as np
+
+# ---- bridge config (same as 32_Plasma/matlab_data.py) ----
+SHORTCUT_PATH = r"C:\ProgramData\Microsoft\Windows\Start Menu\Programs\COMSOL Multiphysics 6.3"
+SHORTCUT_NAME = "COMSOL Multiphysics 6.3 with MATLAB.lnk"
+FULL_PATH = os.path.join(SHORTCUT_PATH, SHORTCUT_NAME)
+
+# ---- inputs / outputs ----
+# Single-file mode:
+INPUT_MPH_PATH = os.path.normpath(r"D:\32_MoviLSTM\Argon_GEC_CCP\argon_gec_ccp.mph")
+# Batch mode (set to None to disable). Globs every .mph under here.
+CASES_DIR = os.path.normpath(r"D:\32_MoviLSTM\Argon_GEC_CCP\cas")
+OUT_DIR = os.path.normpath(r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2")
+
+# ---- what to pull from std2 ----
+# Plasma, Time Periodic (ptp) standard variables for the GEC CCP model.
+# All evaluated on the std2 dataset, so each becomes a (51, N_nodes) array.
+# If a variable does not exist for this .mph it is skipped, not fatal.
+FIELD_EXPRS = [
+    "V",                  # electric potential
+    "ptp.ne",             # electron density
+    "ptp.Te",             # electron temperature
+    "ptp.nepsilon",       # electron energy density (a.k.a. n_eps)
+    "ptp.Re",             # ionization rate (instantaneous)
+    "ptp.Pelec",          # power deposition to electrons (W/m^3)
+    "ptp.Er",             # E-field, r-component
+    "ptp.Ez",             # E-field, z-component
+    "ptp.Jr",             # current density, r
+    "ptp.Jz",             # current density, z
+]
+
+GLOBAL_EXPRS = [
+    "ptp.mct1.Va_per",    # voltage amplitude (V)
+    "ptp.mct1.Vdcb_per",  # DC self-bias (V)
+]
+
+# Dataset tag std2 stores its solution under. COMSOL auto-creates dset2
+# for the second study; if discovery says otherwise we fall back automatically.
+STD2_DATASET_DEFAULT = "dset2"
+
+
+# ---------------- engine bring-up ----------------
+
+def matlab_init(i_path=FULL_PATH):
+    os.startfile(i_path)
+    time.sleep(5)
+    for attempt in range(21):
+        sessions = matlab.engine.find_matlab()
+        if sessions:
+            eng = matlab.engine.connect_matlab(sessions[0])
+            eng.eval("disp('connected')", nargout=0)
+            return eng
+        time.sleep(3)
+    raise RuntimeError("Failed to connect to MATLAB session after retries.")
+
+
+# ---------------- per-.mph helpers ----------------
+
+def find_std2_dataset(eng, tag="model"):
+    """Return the dataset tag whose solution comes from std2.
+
+    Strategy: list dataset tags via mphtags, ask each for its solution tag,
+    pick the one tied to std2/sol2. Falls back to STD2_DATASET_DEFAULT.
+    """
+    try:
+        eng.eval(f"ds_tags = mphtags({tag}.result.dataset);", nargout=0)
+        n = int(eng.eval("numel(ds_tags)", nargout=1))
+        for i in range(1, n + 1):
+            try:
+                # Solution tag attached to dataset i
+                sol_tag = eng.eval(
+                    f"char({tag}.result.dataset(ds_tags{{{i}}}).getString('solution'))",
+                    nargout=1,
+                )
+                ds_tag = eng.eval(f"char(ds_tags{{{i}}})", nargout=1)
+                if isinstance(sol_tag, str) and "sol2" in sol_tag:
+                    return ds_tag
+            except matlab.engine.MatlabExecutionError:
+                continue
+    except matlab.engine.MatlabExecutionError:
+        pass
+    return STD2_DATASET_DEFAULT
+
+
+def eval_field_on_dataset(eng, expr, dataset, tag="model"):
+    """mpheval(expr, 'dataset', dataset) -> (coords, triangulation, values).
+
+    Note: mpheval's `d.t` is the MESH TRIANGULATION (int32, 3 x n_tri or
+    4 x n_tri), NOT time. Pull the time vector separately via
+    get_time_array().
+    """
+    eng.eval(
+        f"d = mpheval({tag}, '{expr}', 'dataset', '{dataset}');", nargout=0,
+    )
+    coords = np.asarray(eng.eval("d.p", nargout=1))
+    values = np.asarray(eng.eval("d.d1", nargout=1))
+    tri = np.asarray(eng.eval("d.t", nargout=1)).astype(np.int32)
+    return coords, values, tri
+
+
+def eval_global_on_dataset(eng, expr, dataset, tag="model"):
+    eng.eval(
+        f"g = mphglobal({tag}, '{expr}', 'dataset', '{dataset}');", nargout=0,
+    )
+    return np.asarray(eng.eval("g", nargout=1)).ravel()
+
+
+def get_time_array(eng, dataset, tag="model"):
+    """Pull the time vector for a time-dependent dataset.
+
+    Resolves the soltag via dataset.getString('solution') -> mphsolinfo.
+    Returns an empty array if the solution is not time-dep (e.g., std1).
+    """
+    try:
+        eng.eval(
+            f"sol_tag = char({tag}.result.dataset('{dataset}').getString('solution'));",
+            nargout=0,
+        )
+        eng.eval(f"info = mphsolinfo({tag}, 'soltag', sol_tag);", nargout=0)
+        return np.asarray(eng.eval("info.solvals", nargout=1)).ravel()
+    except matlab.engine.MatlabExecutionError:
+        return np.array([])
+
+
+def discover_variables(eng, dataset, tag="model", prefix="ptp."):
+    """List variables defined on the geometry that match a name prefix.
+
+    Useful first time on a new .mph to find correct variable names.
+    Calls mphxmeshstats / mphfield to enumerate. Returns a list of names.
+    """
+    try:
+        eng.eval(f"info = mphxmeshinfo({tag});", nargout=0)
+        names = eng.eval("info.fieldnames", nargout=1)
+        out = [str(n) for n in (names if isinstance(names, list) else [names])]
+        if prefix:
+            out = [n for n in out if n.startswith(prefix)]
+        return sorted(out)
+    except matlab.engine.MatlabExecutionError:
+        return []
+
+
+def safe_key(expr):
+    return (
+        expr.replace(".", "_")
+        .replace("(", "_").replace(")", "")
+        .replace(" ", "")
+    )
+
+
+def extract_one(eng, mph_path, out_path):
+    """Load one .mph, dump everything for std2 to a single .npz."""
+    eng.eval(f"model = mphload('{mph_path.replace(chr(92), chr(92)*2)}');", nargout=0)
+    dset = find_std2_dataset(eng)
+    print(f"  std2 dataset = {dset}")
+
+    # Time vector (pulled once from solution metadata, not from mpheval).
+    times = get_time_array(eng, dset)
+    print(f"  time array  -> {times.shape} ({times[0]:.3e} .. {times[-1]:.3e} s)" if times.size else "  time array  -> (none)")
+
+    bundle = {
+        "_dataset": np.array(dset),
+        "_source_mph": np.array(mph_path),
+        "t": times,
+    }
+    coords_saved = False
+    tri_saved = False
+
+    for expr in FIELD_EXPRS:
+        try:
+            coords, values, tri = eval_field_on_dataset(eng, expr, dset)
+        except matlab.engine.MatlabExecutionError as e:
+            print(f"  {expr:<18} SKIP ({str(e).splitlines()[0][:80]})")
+            continue
+        if not coords_saved:
+            bundle["coords"] = coords            # (dim, N)
+            coords_saved = True
+        if not tri_saved:
+            bundle["triangulation"] = tri        # (4, n_tri) — for plotting
+            tri_saved = True
+        bundle[safe_key(expr)] = values          # (T, N)
+        print(f"  {expr:<18} -> {values.shape}")
+
+    for expr in GLOBAL_EXPRS:
+        try:
+            arr = eval_global_on_dataset(eng, expr, dset)
+            bundle[f"g_{safe_key(expr)}"] = arr
+            print(f"  {expr:<22} -> {arr.shape} (global)")
+        except matlab.engine.MatlabExecutionError as e:
+            print(f"  {expr:<22} SKIP ({str(e).splitlines()[0][:80]})")
+
+    np.savez_compressed(out_path, **bundle)
+    # free MATLAB workspace before next case
+    eng.eval("clear model d g info sol_tag", nargout=0)
+    return out_path
+
+
+# ---------------- main / batch ----------------
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    # also render PNG dataset alongside extraction (rendering is cheap;
+    # done inline so it overlaps with COMSOL working on the next case)
+    DATASET_OUT = os.path.normpath(
+        r"D:\32_MoviLSTM\Argon_GEC_CCP\dataset_test_var_p_mu_from_npz"
+    )
+    sys.path.insert(0, os.path.dirname(__file__))
+    try:
+        from npz_to_dataset import render_case, filename_to_casename
+        do_render = True
+    except Exception as e:
+        print(f"WARN: cannot import npz_to_dataset ({e}); skipping PNG render")
+        do_render = False
+
+    if CASES_DIR and os.path.isdir(CASES_DIR):
+        mphs = sorted(glob.glob(os.path.join(CASES_DIR, "*.mph")))
+    else:
+        mphs = [INPUT_MPH_PATH]
+    print(f"cases to process: {len(mphs)}")
+
+    eng = matlab_init()
+    failed = []
+    try:
+        for i, mph in enumerate(mphs):
+            stem = Path(mph).stem
+            out = os.path.join(OUT_DIR, stem + ".npz")
+            casename = filename_to_casename(out, i) if do_render else None
+
+            extracted_now = False
+            if os.path.exists(out):
+                print(f"[{i+1}/{len(mphs)}] npz exists, skip extract: {stem}")
+            else:
+                print(f"[{i+1}/{len(mphs)}] extracting: {stem}")
+                try:
+                    extract_one(eng, mph, out)
+                    extracted_now = True
+                except Exception:
+                    traceback.print_exc()
+                    failed.append(mph)
+                    continue
+
+            # render PNGs from npz (always; idempotent)
+            if do_render:
+                try:
+                    print(f"  -> rendering PNGs as case '{casename}'")
+                    render_case(out, DATASET_OUT, casename=casename, verbose=False)
+                except Exception:
+                    print("  render failed:")
+                    traceback.print_exc()
+
+            # bounce engine every 50 EXTRACTIONS (skips don't count)
+            if extracted_now and (i + 1) % 50 == 0:
+                print(f"-- restarting engine after {i+1} cases --")
+                try:
+                    eng.exit()
+                except Exception:
+                    pass
+                import subprocess
+                for proc in ("MATLAB.exe", "comsolmphserver.exe"):
+                    subprocess.run(["taskkill", "/F", "/IM", proc])
+                eng = matlab_init()
+    finally:
+        if failed:
+            print("FAILED cases:")
+            for f in failed:
+                print("  ", f)
+
+
+if __name__ == "__main__":
+    main()

--- a/32_Plasma/line_profile_3d.py
+++ b/32_Plasma/line_profile_3d.py
@@ -1,0 +1,193 @@
+"""3D surface plot of T_e and n_e along two cut lines vs time.
+
+Two lines:
+  vertical   : r = 0.025 m,  z from 0 to L (gap height)
+  horizontal : z = 0.001 m,  r from 0 to R2 (across the discharge)
+
+Output: 4 separate PNGs, each with a small geometry thumbnail showing
+the cut line used.
+"""
+
+import os
+import sys
+
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import matplotlib.patches as mpatches  # noqa: E402
+import matplotlib.ticker as mticker  # noqa: E402
+import matplotlib.tri as mtri    # noqa: E402
+from matplotlib.tri import LinearTriInterpolator  # noqa: E402
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401, E402
+
+
+def log10_formatter(x, pos):
+    """Format a log10-space value `x` as 10^x in math text."""
+    return rf"$10^{{{int(round(x))}}}$"
+
+# GEC reactor dimensions (m)
+GEOM_R1 = 0.0538
+GEOM_R2 = 0.1016
+GEOM_L = 0.0254
+GEOM_HD = 0.1016
+CHAM_Z_LO = -GEOM_HD / 2 + GEOM_L / 2   # -0.0381
+CHAM_Z_HI = GEOM_HD / 2 + GEOM_L / 2    # +0.0635
+
+
+def draw_geometry_inset(fig, rect, line_pts):
+    """Draw reactor outline + the cut line as a small inset on `fig`.
+
+    rect      : (x, y, w, h) in figure-fraction coordinates.
+    line_pts  : ((r0, z0), (r1, z1)) endpoints in metres.
+    """
+    ax = fig.add_axes(rect)
+    # gap rectangle [0, R1] x [0, L]
+    ax.add_patch(mpatches.Rectangle((0, 0), GEOM_R1, GEOM_L,
+                                    facecolor="#dddddd",
+                                    edgecolor="black", lw=0.8))
+    # chamber rectangle [R1, R2] x [Cham_lo, Cham_hi]
+    ax.add_patch(mpatches.Rectangle(
+        (GEOM_R1, CHAM_Z_LO), GEOM_R2 - GEOM_R1, CHAM_Z_HI - CHAM_Z_LO,
+        facecolor="#dddddd", edgecolor="black", lw=0.8,
+    ))
+    # the cut line
+    (r0, z0), (r1, z1) = line_pts
+    ax.plot([r0, r1], [z0, z1], color="red", lw=2.0)
+    ax.annotate(
+        "", xy=(r1, z1), xytext=(r0, z0),
+        arrowprops=dict(arrowstyle="->", color="red", lw=1.8),
+    )
+    ax.set_xlim(-0.005, GEOM_R2 + 0.005)
+    ax.set_ylim(CHAM_Z_LO - 0.005, CHAM_Z_HI + 0.005)
+    ax.set_aspect("equal")
+    ax.set_xticks([]); ax.set_yticks([])
+    for s in ax.spines.values():
+        s.set_visible(False)
+    ax.set_facecolor("white")
+    ax.set_title("cut line", fontsize=8, pad=2)
+    ax.set_zorder(10)  # keep inset above any 3D-plot bleed
+
+
+def sample_line_over_time(triang, field_TxN, r_line, z_line):
+    """field_TxN shape (T, N) -> returns (T, M) sampled along the line."""
+    out = np.full((field_TxN.shape[0], len(r_line)), np.nan)
+    for i in range(field_TxN.shape[0]):
+        interp = LinearTriInterpolator(triang, field_TxN[i])
+        masked = interp(r_line, z_line)
+        out[i] = masked.filled(np.nan)
+    return out
+
+
+def main(npz_path, out_png):
+    d = np.load(npz_path, allow_pickle=True)
+    r, z = d["coords"]
+    tri = d["triangulation"][:3].T
+    if tri.min() == 1:
+        tri = tri - 1
+    triang = mtri.Triangulation(r, z, tri)
+
+    t = d["t"]                                                  # (51,)
+    Te = d["ptp_Te"]                                            # (51, N)
+    ne = d["ptp_ne"]                                            # (51, N)
+
+    # vertical line through the gap (r=25mm, z=0..L)
+    n_v = 120
+    r_v = np.full(n_v, 0.025)
+    z_v = np.linspace(0.0002, 0.0252, n_v)
+
+    # horizontal line just above the powered electrode (z=1mm, r=0..R2)
+    n_h = 200
+    r_h = np.linspace(0.001, 0.100, n_h)
+    z_h = np.full(n_h, 0.001)
+
+    Te_v = sample_line_over_time(triang, Te, r_v, z_v)
+    ne_v = sample_line_over_time(triang, ne, r_v, z_v)
+    Te_h = sample_line_over_time(triang, Te, r_h, z_h)
+    ne_h = sample_line_over_time(triang, ne, r_h, z_h)
+
+    print(f"vertical   sampled: Te {Te_v.shape}, ne {ne_v.shape}, "
+          f"Te valid {(~np.isnan(Te_v)).sum()/Te_v.size*100:.0f}%")
+    print(f"horizontal sampled: Te {Te_h.shape}, ne {ne_h.shape}, "
+          f"Te valid {(~np.isnan(Te_h)).sum()/Te_h.size*100:.0f}%")
+
+    t_ns = t * 1e9                  # ns
+    z_v_mm = z_v * 1000             # mm
+    r_h_mm = r_h * 1000             # mm
+
+    out_dir = os.path.dirname(out_png)
+    stem = os.path.splitext(os.path.basename(out_png))[0]
+
+    line_v = ((0.025, z_v[0]), (0.025, z_v[-1]))
+    line_h = ((r_h[0], 0.001), (r_h[-1], 0.001))
+
+    NE_LBL = r"$n_e\ (\mathrm{m}^{-3})$"
+    TE_LBL = r"$T_e\ (\mathrm{eV})$"
+    Z_LBL = r"$z\ (\mathrm{mm})$"
+    R_LBL = r"$r\ (\mathrm{mm})$"
+    T_LBL = r"$t\ (\mathrm{ns})$"
+
+    # Apply log10 to n_e (3D matplotlib can't reliably set_zscale('log'))
+    eps = 1e-3   # avoid log(0)
+    ne_v_log = np.log10(np.where(ne_v > eps, ne_v, eps))
+    ne_h_log = np.log10(np.where(ne_h > eps, ne_h, eps))
+
+    panels = [
+        (Te_v, z_v_mm, Z_LBL, TE_LBL,
+         r"$T_e$ along vertical line at $r=25$ mm",
+         "Te_vertical_r25mm", line_v, False),
+        (Te_h, r_h_mm, R_LBL, TE_LBL,
+         r"$T_e$ along horizontal line at $z=1$ mm",
+         "Te_horizontal_z1mm", line_h, False),
+        (ne_v_log, z_v_mm, Z_LBL, NE_LBL,
+         r"$n_e$ along vertical line at $r=25$ mm  (log scale)",
+         "ne_vertical_r25mm", line_v, True),
+        (ne_h_log, r_h_mm, R_LBL, NE_LBL,
+         r"$n_e$ along horizontal line at $z=1$ mm  (log scale)",
+         "ne_horizontal_z1mm", line_h, True),
+    ]
+    for arr, axis, xlab, zlab, title, key, line, is_log in panels:
+        fig = plt.figure(figsize=(9, 7))
+        ax = fig.add_subplot(111, projection="3d")
+        S, T = np.meshgrid(axis, t_ns)
+        Z = np.where(np.isnan(arr), 0, arr)
+        surf = ax.plot_surface(
+            S, T, Z, cmap="plasma", edgecolor="none",
+            rcount=51, ccount=120, antialiased=True,
+        )
+        ax.set_xlabel(xlab, labelpad=8)
+        ax.set_ylabel(T_LBL, labelpad=8)
+        ax.set_zlabel(zlab, labelpad=10)
+        ax.set_title(title, fontsize=13)
+        ax.view_init(elev=25, azim=-60)
+
+        if is_log:
+            # axis ticks at integer log decades, formatted as 10^x
+            zmin, zmax = int(np.floor(np.nanmin(arr))), int(np.ceil(np.nanmax(arr)))
+            ticks = np.arange(zmin, zmax + 1)
+            ax.set_zticks(ticks)
+            ax.zaxis.set_major_formatter(mticker.FuncFormatter(log10_formatter))
+
+        cb = fig.colorbar(surf, ax=ax, shrink=0.55, pad=0.10, location="right")
+        cb.set_label(zlab)
+        if is_log:
+            cb.set_ticks(np.arange(int(np.floor(np.nanmin(arr))),
+                                   int(np.ceil(np.nanmax(arr))) + 1))
+            cb.ax.yaxis.set_major_formatter(mticker.FuncFormatter(log10_formatter))
+
+        draw_geometry_inset(fig, rect=(0.01, 0.74, 0.18, 0.22),
+                            line_pts=line)
+
+        path = os.path.join(out_dir, f"{stem}_{key}.png")
+        fig.savefig(path, dpi=120, bbox_inches="tight")
+        plt.close(fig)
+        print(f"saved -> {path}")
+
+
+if __name__ == "__main__":
+    npz = (sys.argv[1] if len(sys.argv) > 1 else
+           r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2\argon_gec_ccp.npz")
+    out = (sys.argv[2] if len(sys.argv) > 2 else
+           r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2\argon_gec_ccp_lineprofile3d.png")
+    main(npz, out)

--- a/32_Plasma/npz_to_dataset.py
+++ b/32_Plasma/npz_to_dataset.py
@@ -1,0 +1,147 @@
+"""
+Render std2 npz files into the dataset_test_var_p_mu image format.
+
+Per case (one .npz):
+    <out>/input/<casename>/input01.png  ... input51.png    <- T_e frames
+    <out>/output/<casename>/output01.png ... output51.png  <- n_e frames
+
+Reproduces the structure that 32_Plasma/matlab_data.py used to produce via
+COMSOL anim2/anim3 exports — but generated purely from the saved .npz, no
+COMSOL or MATLAB launch required. Same colormap, same fixed ranges as
+view_npz.py so the dataset is internally consistent.
+"""
+
+import argparse
+import glob
+import os
+import re
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.tri as mtri
+import numpy as np
+from matplotlib.colors import LogNorm
+
+
+def filename_to_casename(npz_path, counter):
+    """Map 'material=test ..._A=0.14475_offset=...' to '0A_0.14475'."""
+    stem = Path(npz_path).stem
+    m = re.search(r"_A=([0-9.]+)_offset=", stem)
+    if m:
+        return f"{counter}A_{m.group(1)}"
+    return f"{counter}A_{stem}"
+
+# Same fixed ranges as view_npz.py — keeps the dataset comparable across cases.
+NE_VMIN, NE_VMAX = 2e9, 5e15
+TE_VMIN, TE_VMAX = 1.0, 10.0
+
+# Image size — original dataset is 640x480 px.
+IMG_WIDTH_IN = 6.4
+IMG_HEIGHT_IN = 4.8
+IMG_DPI = 100  # -> 640x480
+
+CMAP = "plasma"
+
+
+def _load(npz_path):
+    d = np.load(npz_path, allow_pickle=True)
+    coords = d["coords"]
+    r, z = coords[0], coords[1]
+    tri_raw = d["triangulation"]
+    tri = (tri_raw[:3].T if tri_raw.shape[0] in (3, 4) else tri_raw[:, :3])
+    if tri.min() == 1:
+        tri = tri - 1
+    triang = mtri.Triangulation(r, z, tri)
+    return d, triang
+
+
+def _render_frame(triang, values, _grid_unused, norm, vmin, vmax, out_path):
+    """Render one frame with FLAT shading (one solid color per triangle).
+
+    tripcolor + shading='flat' assigns each triangle the mean of its 3 vertex
+    values, then maps that single scalar through cmap+norm. Result:
+      - smooth?  no — block-by-block, each triangle a uniform color
+      - 1-1?     yes — same value always maps to same RGB
+    Outside the triangulation -> no triangles -> figure facecolor (white).
+    """
+    fig = plt.figure(figsize=(IMG_WIDTH_IN, IMG_HEIGHT_IN), dpi=IMG_DPI,
+                     facecolor="white")
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.set_facecolor("white")
+    if norm is not None:
+        ax.tripcolor(triang, values, shading="flat", cmap=CMAP, norm=norm)
+    else:
+        ax.tripcolor(triang, values, shading="flat", cmap=CMAP,
+                     vmin=vmin, vmax=vmax)
+    ax.set_aspect("equal")
+    ax.set_axis_off()
+    ax.set_xlim(triang.x.min(), triang.x.max())
+    ax.set_ylim(triang.y.min(), triang.y.max())
+    fig.savefig(out_path, dpi=IMG_DPI, pad_inches=0, facecolor="white")
+    plt.close(fig)
+
+
+def render_case(npz_path, out_root, casename=None, verbose=True):
+    """Render one npz to <out_root>/{input,output}/<casename>/{input,output}NN.png."""
+    d, triang = _load(npz_path)
+    Te = d["ptp_Te"]                  # (51, N)
+    ne = d["ptp_ne"]                  # (51, N)
+    n_frames = Te.shape[0]
+
+    if casename is None:
+        casename = Path(npz_path).stem
+
+    in_dir = Path(out_root) / "input" / casename
+    out_dir = Path(out_root) / "output" / casename
+    in_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    ne_norm = LogNorm(vmin=NE_VMIN, vmax=NE_VMAX)
+    Te_clip = np.clip(Te, TE_VMIN, TE_VMAX)
+    ne_clip = np.clip(ne, NE_VMIN, NE_VMAX)
+
+    for i in range(n_frames):
+        idx = f"{i+1:02d}"
+        _render_frame(
+            triang, Te_clip[i], None, None, TE_VMIN, TE_VMAX,
+            in_dir / f"input{idx}.png",
+        )
+        _render_frame(
+            triang, ne_clip[i], None, ne_norm, None, None,
+            out_dir / f"output{idx}.png",
+        )
+    if verbose:
+        print(f"  {casename:<40} {n_frames} frames -> {in_dir.parent.name}/{casename}/")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("npz", nargs="?",
+                   default=r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2\argon_gec_ccp.npz",
+                   help="single .npz path, OR a directory of .npz to batch")
+    p.add_argument("--out", default=r"D:\32_MoviLSTM\Argon_GEC_CCP\dataset_test_var_p_mu_from_npz",
+                   help="root output dir; will get input/ and output/ subdirs")
+    p.add_argument("--casename", default=None,
+                   help="override case folder name (single-file mode only)")
+    args = p.parse_args()
+
+    if os.path.isdir(args.npz):
+        files = sorted(glob.glob(os.path.join(args.npz, "*.npz")))
+    else:
+        files = [args.npz]
+    print(f"cases: {len(files)}  ->  {args.out}")
+
+    for i, f in enumerate(files):
+        if args.casename and len(files) == 1:
+            cn = args.casename
+        else:
+            cn = filename_to_casename(f, i)
+        print(f"[{i+1}/{len(files)}] {cn}")
+        render_case(f, args.out, casename=cn)
+
+
+if __name__ == "__main__":
+    main()

--- a/32_Plasma/npz_to_dataset_60x80.py
+++ b/32_Plasma/npz_to_dataset_60x80.py
@@ -1,0 +1,153 @@
+"""
+Render std2 npz files into a UNIFORM 60x80 sample grid, output as 640x480 PNG.
+
+Key difference from npz_to_dataset.py:
+  - That one rendered the FEM triangulation directly (block density follows
+    mesh — dense near sheath, sparse in bulk).
+  - This one resamples onto a uniform 60x80 grid (cells are 1.69 mm tall x
+    1.27 mm wide). Each cell -> one solid color block in the PNG.
+    Sheath detail is lost; bulk is preserved at its natural resolution.
+
+Per-cell value comes from LinearTriInterpolator at the cell center
+(no smoothing across cells — imshow uses interpolation='nearest').
+Cells whose center falls outside the triangulation (inside the metal
+electrodes) -> NaN -> rendered as the white figure background.
+"""
+
+import argparse
+import glob
+import os
+import re
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.tri as mtri
+import numpy as np
+from matplotlib.colors import LogNorm
+from matplotlib.tri import LinearTriInterpolator
+
+# Color ranges — same as flat-shading dataset for cross-comparability.
+NE_VMIN, NE_VMAX = 2e9, 5e15
+TE_VMIN, TE_VMAX = 1.0, 10.0
+
+# PNG canvas (kept identical to the FEM dataset PNGs).
+IMG_WIDTH_IN = 6.4
+IMG_HEIGHT_IN = 4.8
+IMG_DPI = 100  # -> 640x480 px
+
+# Uniform value grid resolution.
+GRID_H = 60
+GRID_W = 80
+
+CMAP = "plasma"
+
+
+def filename_to_casename(npz_path, counter):
+    stem = Path(npz_path).stem
+    m = re.search(r"_A=([0-9.]+)_offset=", stem)
+    if m:
+        return f"{counter}A_{m.group(1)}"
+    return f"{counter}A_{stem}"
+
+
+def _load(npz_path):
+    d = np.load(npz_path, allow_pickle=True)
+    coords = d["coords"]
+    r, z = coords[0], coords[1]
+    tri_raw = d["triangulation"]
+    tri = (tri_raw[:3].T if tri_raw.shape[0] in (3, 4) else tri_raw[:, :3])
+    if tri.min() == 1:
+        tri = tri - 1
+    triang = mtri.Triangulation(r, z, tri)
+    return d, triang
+
+
+def _make_uniform_grid(triang, grid_h=GRID_H, grid_w=GRID_W):
+    """Cell-center grid covering the triangulation's bounding box."""
+    xmin, xmax = float(triang.x.min()), float(triang.x.max())
+    ymin, ymax = float(triang.y.min()), float(triang.y.max())
+    dx = (xmax - xmin) / grid_w
+    dy = (ymax - ymin) / grid_h
+    xs = np.linspace(xmin + dx / 2, xmax - dx / 2, grid_w)
+    ys = np.linspace(ymin + dy / 2, ymax - dy / 2, grid_h)
+    return np.meshgrid(xs, ys), (xmin, xmax, ymin, ymax)
+
+
+def _render_frame(triang, values, grid, extent, norm, vmin, vmax, out_path):
+    """Sample on uniform grid (cell centers), render as solid blocks."""
+    XG, YG = grid
+    interp = LinearTriInterpolator(triang, values)
+    Z = interp(XG, YG)  # masked array — NaN outside geometry
+
+    fig = plt.figure(figsize=(IMG_WIDTH_IN, IMG_HEIGHT_IN), dpi=IMG_DPI,
+                     facecolor="white")
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.set_facecolor("white")
+    if norm is not None:
+        ax.imshow(Z, origin="lower", cmap=CMAP, norm=norm,
+                  extent=extent, interpolation="nearest", aspect="equal")
+    else:
+        ax.imshow(Z, origin="lower", cmap=CMAP, vmin=vmin, vmax=vmax,
+                  extent=extent, interpolation="nearest", aspect="equal")
+    ax.set_xlim(extent[0], extent[1])
+    ax.set_ylim(extent[2], extent[3])
+    ax.set_axis_off()
+    fig.savefig(out_path, dpi=IMG_DPI, pad_inches=0, facecolor="white")
+    plt.close(fig)
+
+
+def render_case(npz_path, out_root, casename=None, verbose=True):
+    d, triang = _load(npz_path)
+    Te = d["ptp_Te"]
+    ne = d["ptp_ne"]
+    n_frames = Te.shape[0]
+
+    if casename is None:
+        casename = Path(npz_path).stem
+
+    in_dir = Path(out_root) / "input" / casename
+    out_dir = Path(out_root) / "output" / casename
+    in_dir.mkdir(parents=True, exist_ok=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Per-case grid (same for all 51 frames within a case).
+    grid, extent = _make_uniform_grid(triang)
+    ne_norm = LogNorm(vmin=NE_VMIN, vmax=NE_VMAX)
+    Te_clip = np.clip(Te, TE_VMIN, TE_VMAX)
+    ne_clip = np.clip(ne, NE_VMIN, NE_VMAX)
+
+    for i in range(n_frames):
+        idx = f"{i+1:02d}"
+        _render_frame(triang, Te_clip[i], grid, extent, None,
+                      TE_VMIN, TE_VMAX, in_dir / f"input{idx}.png")
+        _render_frame(triang, ne_clip[i], grid, extent, ne_norm,
+                      None, None, out_dir / f"output{idx}.png")
+    if verbose:
+        print(f"  {casename:<40} {n_frames} frames @ {GRID_H}x{GRID_W}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("npz", nargs="?",
+                   default=r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2\argon_gec_ccp.npz")
+    p.add_argument("--out",
+                   default=r"D:\32_MoviLSTM\Argon_GEC_CCP\dataset_test_var_p_mu_from_npz_60x80")
+    p.add_argument("--casename", default=None)
+    args = p.parse_args()
+
+    if os.path.isdir(args.npz):
+        files = sorted(glob.glob(os.path.join(args.npz, "*.npz")))
+    else:
+        files = [args.npz]
+    print(f"cases: {len(files)}  ->  {args.out}  (grid {GRID_H}x{GRID_W})")
+    for i, f in enumerate(files):
+        cn = args.casename if (args.casename and len(files) == 1) else filename_to_casename(f, i)
+        print(f"[{i+1}/{len(files)}] {cn}")
+        render_case(f, args.out, casename=cn)
+
+
+if __name__ == "__main__":
+    main()

--- a/32_Plasma/view_npz.py
+++ b/32_Plasma/view_npz.py
@@ -1,0 +1,180 @@
+"""Quick inspector for one std2 .npz produced by extract_std2.py.
+
+Prints summary, then renders 2 figures:
+  fig 1: ne and Te snapshots at frames 0, 12, 25, 37, 50  (10 panels)
+  fig 2: time series at the gap centerline node closest to (r=0, z=L/2)
+
+PNGs land next to the .npz with the same stem.
+"""
+
+import os
+import sys
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")  # no GUI needed
+import matplotlib.pyplot as plt
+import matplotlib.tri as mtri
+from matplotlib.colors import LogNorm
+
+# Fixed colorbar ranges for cross-case comparability.
+# n_e spans 6 orders of magnitude -> log scale.
+NE_VMIN, NE_VMAX = 2e9, 5e15
+TE_VMIN, TE_VMAX = 1.0, 10.0
+
+# Sheath zoom window — z range to zoom into for the high-gradient region.
+# The driven electrode sits at z=0; sheath extends ~3 mm into the gap.
+SHEATH_ZOOM_Z = (-0.001, 0.005)   # 6 mm tall window straddling the electrode
+SHEATH_ZOOM_R = (0.0, 0.054)      # only over the powered electrode radius
+
+
+def main(npz_path):
+    d = np.load(npz_path, allow_pickle=True)
+    print(f"=== {npz_path}")
+    print("keys + shapes:")
+    for k in sorted(d.files):
+        a = d[k]
+        s = f"  {k:<22} {a.shape}  {a.dtype}"
+        if a.ndim == 0:
+            s += f"  = {a}"
+        elif a.ndim == 1:
+            s += f"  range [{a.min():.3e}, {a.max():.3e}]"
+        else:
+            s += f"  range [{a.min():.3e}, {a.max():.3e}]"
+        print(s)
+
+    coords = d["coords"]            # (2, N)
+    r, z = coords[0], coords[1]
+    t = d["t"]                       # (51,)
+    ne = d["ptp_ne"]                 # (51, N)
+    Te = d["ptp_Te"]                 # (51, N)
+
+    # Build the matplotlib triangulation. Auto-detect 0- vs 1-based indexing.
+    tri_raw = d["triangulation"]
+    if tri_raw.shape[0] in (3, 4):
+        tri = tri_raw[:3].T          # (n_tri, 3)
+    else:
+        tri = tri_raw[:, :3]
+    if tri.min() == 1:
+        tri = tri - 1
+    triang = mtri.Triangulation(r, z, tri)
+
+    stem = os.path.splitext(npz_path)[0]
+    frames = [0, 12, 25, 37, 50]
+
+    # ---- figure 1: spatial snapshots at 5 phases ----
+    # plasma colormap, FIXED colorbar range across all frames AND across
+    # cases (constants at top of file) so plots from different sweep cases
+    # can be visually compared. n_e on log scale because dynamic range is
+    # 6 decades; T_e linear.
+    cmap = "plasma"
+    ne_norm = LogNorm(vmin=NE_VMIN, vmax=NE_VMAX)
+    ne_levels = np.logspace(np.log10(NE_VMIN), np.log10(NE_VMAX), 21)
+    Te_levels = np.linspace(TE_VMIN, TE_VMAX, 21)
+    # clip so out-of-range values don't blow up LogNorm
+    ne_clip = np.clip(ne, NE_VMIN, NE_VMAX)
+    Te_clip = np.clip(Te, TE_VMIN, TE_VMAX)
+
+    fig, axes = plt.subplots(2, 5, figsize=(20, 7), constrained_layout=True)
+    for j, fi in enumerate(frames):
+        cs0 = axes[0, j].tricontourf(
+            triang, ne_clip[fi], levels=ne_levels, cmap=cmap,
+            norm=ne_norm, extend="both",
+        )
+        axes[0, j].set_title(f"n_e   t = {t[fi]*1e9:.1f} ns")
+        axes[0, j].set_aspect("equal")
+        axes[0, j].set_xlabel("r (m)")
+
+        cs1 = axes[1, j].tricontourf(
+            triang, Te_clip[fi], levels=Te_levels, cmap=cmap,
+            vmin=TE_VMIN, vmax=TE_VMAX, extend="both",
+        )
+        axes[1, j].set_title(f"T_e   t = {t[fi]*1e9:.1f} ns")
+        axes[1, j].set_aspect("equal")
+        axes[1, j].set_xlabel("r (m)")
+
+    axes[0, 0].set_ylabel("z (m)")
+    axes[1, 0].set_ylabel("z (m)")
+
+    # one shared colorbar per row
+    fig.colorbar(cs0, ax=axes[0, :], shrink=0.85,
+                 label=f"n_e (1/m^3)  log[{NE_VMIN:.0e}, {NE_VMAX:.0e}]")
+    fig.colorbar(cs1, ax=axes[1, :], shrink=0.85,
+                 label=f"T_e  [{TE_VMIN}, {TE_VMAX}]")
+
+    fig.suptitle(
+        f"{os.path.basename(npz_path)} — snapshots (fixed range, plasma cmap)",
+        fontsize=14,
+    )
+    out1 = stem + "_snapshots.png"
+    fig.savefig(out1, dpi=120)
+    print(f"\nsaved -> {out1}")
+
+    # ---- figure 1b: same data, zoomed onto the sheath / driven-electrode ----
+    fig, axes = plt.subplots(2, 5, figsize=(20, 6), constrained_layout=True)
+    for j, fi in enumerate(frames):
+        cs0 = axes[0, j].tricontourf(
+            triang, ne_clip[fi], levels=ne_levels, cmap=cmap,
+            norm=ne_norm, extend="both",
+        )
+        axes[0, j].set_xlim(*SHEATH_ZOOM_R)
+        axes[0, j].set_ylim(*SHEATH_ZOOM_Z)
+        axes[0, j].set_title(f"n_e   t = {t[fi]*1e9:.1f} ns")
+        axes[0, j].set_aspect("auto")  # exaggerate z to show structure
+
+        cs1 = axes[1, j].tricontourf(
+            triang, Te_clip[fi], levels=Te_levels, cmap=cmap,
+            vmin=TE_VMIN, vmax=TE_VMAX, extend="both",
+        )
+        axes[1, j].set_xlim(*SHEATH_ZOOM_R)
+        axes[1, j].set_ylim(*SHEATH_ZOOM_Z)
+        axes[1, j].set_title(f"T_e   t = {t[fi]*1e9:.1f} ns")
+        axes[1, j].set_aspect("auto")
+
+        # overlay the actual mesh nodes so you can SEE the resolution
+        in_window = (
+            (r >= SHEATH_ZOOM_R[0]) & (r <= SHEATH_ZOOM_R[1]) &
+            (z >= SHEATH_ZOOM_Z[0]) & (z <= SHEATH_ZOOM_Z[1])
+        )
+        for ax in (axes[0, j], axes[1, j]):
+            ax.plot(r[in_window], z[in_window], ".",
+                    ms=1.0, color="white", alpha=0.4)
+
+    axes[0, 0].set_ylabel("z (m)")
+    axes[1, 0].set_ylabel("z (m)")
+    fig.colorbar(cs0, ax=axes[0, :], shrink=0.85,
+                 label=f"n_e (1/m^3)  log[{NE_VMIN:.0e}, {NE_VMAX:.0e}]")
+    fig.colorbar(cs1, ax=axes[1, :], shrink=0.85,
+                 label=f"T_e  [{TE_VMIN}, {TE_VMAX}]")
+    fig.suptitle(
+        f"{os.path.basename(npz_path)} — sheath zoom (z ∈ {SHEATH_ZOOM_Z} m, white dots = mesh nodes)",
+        fontsize=13,
+    )
+    out1z = stem + "_sheath.png"
+    fig.savefig(out1z, dpi=120)
+    print(f"saved -> {out1z}")
+
+    # ---- figure 2: time series at gap-center, on axis (r ~ 0, z ~ midgap) ----
+    L = z.max() - z.min()
+    z_mid = z.min() + 0.5 * L
+    score = np.hypot(r, z - z_mid)
+    k = int(np.argmin(score))
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4), constrained_layout=True)
+    axes[0].plot(t * 1e9, ne[:, k], lw=1.5)
+    axes[0].set_xlabel("t (ns)")
+    axes[0].set_ylabel("n_e (1/m^3)")
+    axes[0].set_title(f"n_e at node {k}  (r={r[k]:.4f}, z={z[k]:.4f})")
+    axes[0].grid(True)
+    axes[1].plot(t * 1e9, Te[:, k], lw=1.5, color="C1")
+    axes[1].set_xlabel("t (ns)")
+    axes[1].set_ylabel("T_e")
+    axes[1].set_title(f"T_e at node {k}")
+    axes[1].grid(True)
+    out2 = stem + "_timeseries.png"
+    fig.savefig(out2, dpi=120)
+    print(f"saved -> {out2}")
+
+
+if __name__ == "__main__":
+    npz = sys.argv[1] if len(sys.argv) > 1 else r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2\argon_gec_ccp.npz"
+    main(npz)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+Drives **parameter sweeps over COMSOL Multiphysics models** from Python by piping through MATLAB. Each iteration loads a `.mph` model, sets parameters, runs the study, exports input/output images per case, and saves the resulting `.mph`. The exported image pairs are intended as training data for downstream ML models.
+
+Two active sweep projects live in this repo, each with its own `matlab_data.py`:
+- `project_IHCP/` — Inverse Heat Conduction Problem (heat-flux boundary, materials `pm1000` / `sio2` / `ptrh`, heat-flux types `constant` / `sin`).
+- `32_Plasma/` — Argon GEC CCP plasma sim (sweeps `pgas` pressure).
+
+The root `matlab_data.py` is the IHCP variant; `32_Plasma/matlab_data.py` is the plasma variant. They share the same launch/connect/sweep skeleton and diverge in paths, parameter names, and the boundary/study identifiers passed to COMSOL.
+
+`model.py` is an unrelated TensorFlow MNIST tutorial and is not part of the pipeline.
+
+## How the Python ↔ MATLAB ↔ COMSOL bridge works
+
+This is the non-obvious part — the launch sequence is fragile and order-dependent:
+
+1. Python calls `os.startfile(...)` on the Windows shortcut **"COMSOL Multiphysics 6.3 with MATLAB.lnk"** (path hardcoded in each `matlab_data.py`). It must be the `.lnk`, not `matlab.exe` — only the COMSOL-with-MATLAB launcher loads the LiveLink classes that `mphload`/`mphrun`/`mphsave` need.
+2. COMSOL's bundled `comsolinit.m` (vendor file, copied into `project_IHCP/` for reference) auto-runs and looks for **`comsolstartup.m` in the user's home directory** (`%USERPROFILE%`) or on the MATLAB path.
+3. **`matlab.engine.shareEngine` must run somewhere during MATLAB startup.** This is what makes the session discoverable by Python. There are two equally valid places to put it:
+   - `comsolstartup.m` in `%USERPROFILE%` (or on MATLAB path) — the COMSOL-recommended hook.
+   - `startup.m` in MATLAB's user dir (`%USERPROFILE%\Documents\MATLAB\startup.m`) — MATLAB's native mechanism, runs every session regardless of COMSOL. **This is what the current dev machine actually uses**, alongside `cd D:\32_MoviLSTM\Argon_GEC_CCP` to set the working directory for the plasma sweep.
+4. Python sleeps (5–13s), then polls `matlab.engine.find_matlab()` and `connect_matlab()` until the shared session appears (up to 20 retries).
+
+**Implication for edits:** if neither `comsolstartup.m` nor `startup.m` calls `shareEngine`, Python will never connect. The repo's root `comsolstartup.m` is the IHCP-project variant and is **not** what the running setup uses — don't be misled by it. The README's terse hint — "should edited the startup.m for matlab" — refers to this requirement.
+
+The MATLAB code itself is built as Python f-strings inside `eng.eval(""" ... """, nargout=0)`. Curly braces in MATLAB syntax become `{{` `}}` if they're ever needed; right now the scripts only interpolate scalars and paths, so plain `{var}` works.
+
+## Memory leak workaround
+
+COMSOL/MATLAB leak memory across iterations. Every 50 cases, the sweep:
+```
+eng.exit()
+taskkill /F /IM MATLAB.exe
+taskkill /F /IM comsolmphserver.exe
+matlab_init(...)   # full relaunch
+```
+When modifying the sweep loop, preserve this counter-based restart — long sweeps without it will OOM.
+
+`model.hist.disable;` in the MATLAB block exists for the same reason (prevents per-iteration model-history accumulation inside a single MATLAB session).
+
+## Running a sweep
+
+There is no test suite, build system, or lint config. Operation is manual:
+
+1. Ensure `comsolstartup.m` is at `%USERPROFILE%\comsolstartup.m` (or on MATLAB path) and points `cd(...)` at the directory containing the target `.mph`.
+2. Edit the `material` / `heatflux_type` / `parameter_type` constants near the top of the relevant `matlab_data.py` and confirm the hardcoded `C:\`, `D:\`, `E:\` paths exist on the machine.
+3. Confirm the COMSOL shortcut path matches the installed COMSOL version (currently 6.3).
+4. `python matlab_data.py` (root, for IHCP) or `python 32_Plasma/matlab_data.py` (for plasma).
+
+Dependencies: `pip install -r requirements.txt` (the key dep is `matlabengine`, which must match the installed MATLAB version — currently `25.1.2`). `environment.yml` is a full conda export of an unrelated `base` env and is not the intended install path.
+
+## Platform constraints
+
+- **Windows-only.** Hardcoded drive letters, `.lnk` shortcuts, `taskkill`, and `os.startfile` are all non-portable. Don't refactor these toward cross-platform unless asked — they reflect the actual deployment.
+- **MATLAB engine version must match installed MATLAB.** Bumping `matlabengine` in `requirements.txt` without bumping the MATLAB install (or vice versa) breaks `import matlab.engine`.
+- The `generate.ipynb` notebook output shows `ModuleNotFoundError: No module named 'matlab'` — that's a stale kernel state, not a code bug; it just means the notebook was last run in a non-MATLAB venv.
+
+## Conventions when editing the sweep scripts
+
+- The COMSOL identifiers in the f-string MATLAB block (`'ht_PM1000'`, `'hf_BC'`, `'pg3'`, `'anim1'`, `'anim3'`, `'std1'`, `'std2'`, etc.) are **tag names defined inside the `.mph` file**. They are not arbitrary — changing them in Python without changing the model produces silent COMSOL errors. To discover the right tags, open the `.mph` in COMSOL and check the Model Builder tree, or use `mphtags(model, 'result')` (see `project_IHCP/IHCP.m` for an example of building a model from scratch and naming these tags).
+- Image export uses `model.result.export('animN').run()`, where `animN` is a pre-configured animation export node in the `.mph`. The Python script only sets `imagefilename`; everything else (frame rate, view, color range) is baked into the model.

--- a/_discover_ptp_vars.py
+++ b/_discover_ptp_vars.py
@@ -1,0 +1,58 @@
+"""Discover all ptp.* variables defined on the GEC model."""
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "32_Plasma"))
+
+import matlab.engine
+
+sessions = matlab.engine.find_matlab()
+eng = matlab.engine.connect_matlab(sessions[0])
+print("connected")
+
+# Model is already loaded as 'model' in MATLAB workspace from last run
+# (extract_one called clear, so reload)
+mph = r"D:\32_MoviLSTM\Argon_GEC_CCP\argon_gec_ccp.mph"
+eng.eval(f"model = mphload('{mph.replace(chr(92), chr(92)*2)}');", nargout=0)
+
+# Method 1: mphxmeshinfo gives field names of solved variables
+print("\n=== mphxmeshinfo fieldnames (solved DOFs) ===")
+eng.eval("info = mphxmeshinfo(model);", nargout=0)
+try:
+    n = int(eng.eval("numel(info.fieldnames)", nargout=1))
+    for i in range(1, n + 1):
+        name = eng.eval(f"info.fieldnames{{{i}}}", nargout=1)
+        print(f"  {name}")
+except Exception as e:
+    print(f"  fieldnames lookup failed: {e}")
+
+# Method 2: dump full ptp.* variable namespace via a 'who' on a domain
+print("\n=== sample ptp.* variables (first dataset, evaluated names) ===")
+candidates = [
+    # densities and energy
+    "ptp.ne", "ptp.Te", "ptp.eps", "ptp.epse", "ptp.we", "ptp.ne_eps",
+    "ptp.cAr_1p", "ptp.ni_Ar_1p", "ptp.ni",
+    # power deposition
+    "ptp.Qrh", "ptp.Pdep", "ptp.Pelec_dep", "ptp.Pe", "ptp.Q_pl", "ptp.Qpl",
+    "ptp.Joule", "ptp.Joul",
+    # current densities
+    "ptp.Je_r", "ptp.Je_z", "ptp.Ji_r", "ptp.Ji_z", "ptp.J_r", "ptp.J_z",
+    "ptp.Jc_r", "ptp.Jc_z", "ptp.Jcond_r", "ptp.Jcond_z",
+    # electric quantities
+    "ptp.E", "ptp.Er", "ptp.Ez", "ptp.normE",
+    # known good
+    "V", "ptp.ne", "ptp.Re", "ptp.Te",
+]
+ok, bad = [], []
+for c in candidates:
+    try:
+        eng.eval(f"v = mphmean(model, '{c}', 'volume', 'dataset', 'dset3');", nargout=0)
+        ok.append(c)
+    except matlab.engine.MatlabExecutionError as e:
+        line = str(e).splitlines()[0] if str(e).strip() else "(unknown)"
+        bad.append(c)
+print("  OK:")
+for c in ok:
+    print(f"    {c}")
+print("  not found:")
+for c in bad:
+    print(f"    {c}")

--- a/_smoke_extract_std2.py
+++ b/_smoke_extract_std2.py
@@ -1,0 +1,33 @@
+"""Smoke test: run extract_std2.extract_one() on the single tutorial .mph."""
+import os
+import sys
+import time
+
+# make `from extract_std2 import ...` work
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "32_Plasma"))
+
+from extract_std2 import matlab_init, extract_one  # noqa: E402
+
+MPH = r"D:\32_MoviLSTM\Argon_GEC_CCP\argon_gec_ccp.mph"
+OUT_DIR = r"D:\32_MoviLSTM\Argon_GEC_CCP\extracted_std2"
+os.makedirs(OUT_DIR, exist_ok=True)
+out = os.path.join(OUT_DIR, "argon_gec_ccp.npz")
+
+t0 = time.time()
+print(f"connecting to MATLAB...")
+eng = matlab_init()
+print(f"connected ({time.time() - t0:.1f}s)")
+
+print(f"extracting std2 -> {out}")
+t1 = time.time()
+extract_one(eng, MPH, out)
+print(f"done ({time.time() - t1:.1f}s extraction; {time.time() - t0:.1f}s total)")
+
+# show what came out
+import numpy as np
+d = np.load(out, allow_pickle=True)
+print("\nkeys + shapes:")
+for k in d.files:
+    a = d[k]
+    print(f"  {k:<28} {a.shape}  {a.dtype}")
+print(f"\nsize on disk: {os.path.getsize(out) / 1e6:.2f} MB")


### PR DESCRIPTION
## Summary

- New `32_Plasma/extract_std2.py` extracts every Time Periodic (std2) field per saved `.mph` (`V`, `ptp.ne`, `ptp.Te`, `ptp.nepsilon`, `ptp.Re`, `ptp.Pelec`, `ptp.Er/Ez`, `ptp.Jr/Jz` plus globals `Va_per`, `Vdcb_per`) into one `.npz` per case, with mesh coords + triangulation + the 51-sample period time vector. Reuses the same launch chain (`.lnk` → `comsolinit.m` → `shareEngine`) as `matlab_data.py`, including the every-50-cases engine bounce for the COMSOL/MATLAB memory leak.
- New `32_Plasma/npz_to_dataset.py` (FEM triangulation, flat-shaded) and `32_Plasma/npz_to_dataset_60x80.py` (uniform 60x80 resample) re-render the `input/`+`output/` PNG dataset purely from the saved `.npz` — no COMSOL needed once extraction is done. Same color ranges and PNG canvas as the existing dataset for cross-case comparability.
- New `32_Plasma/view_npz.py` (per-case inspector: snapshots, sheath zoom, time series), `32_Plasma/line_profile_3d.py` (3D surface plots along cut lines), `32_Plasma/extract_result.py` (single-case version of std2 extraction), and two smoke/discovery scripts (`_discover_ptp_vars.py`, `_smoke_extract_std2.py`).
- Adds `CLAUDE.md` documenting the Python ↔ MATLAB ↔ COMSOL bridge order-of-operations, the `shareEngine` requirement, the 50-iteration restart workaround, and the meaning of in-`.mph` tag names like `std2`/`anim3` so the bridge can be edited safely.

## Test plan

- [ ] Run `python _smoke_extract_std2.py` on the tutorial `argon_gec_ccp.mph` and confirm it produces a `.npz` with `coords`, `triangulation`, `t (51,)`, and `ptp_*` fields of shape `(51, N)`.
- [ ] Run `python 32_Plasma/view_npz.py <npz>` and confirm `_snapshots.png`, `_sheath.png`, `_timeseries.png` are written next to the npz.
- [ ] Run `python 32_Plasma/npz_to_dataset.py <dir-of-npz>` and confirm `dataset_test_var_p_mu_from_npz/{input,output}/<case>/{input,output}NN.png` (51 frames each) are produced.
- [ ] Run a batch `python 32_Plasma/extract_std2.py` against `cas/` and confirm the every-50-cases MATLAB/COMSOL restart fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)